### PR TITLE
Fix play some .wav file have tail noise

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ environment:
   PYTHON_ARCH: "32"
   matrix:
     - build_type: windows32_cmake_test
-    - build_type: android_cpp_tests
+#    - build_type: android_cpp_tests
 #    - build_type: android_lua_tests
 #    - build_type: android_cocos_new_test
 #    - build_type: android_cpp_empty_test

--- a/cocos/audio/AudioCache.cpp
+++ b/cocos/audio/AudioCache.cpp
@@ -183,48 +183,8 @@ void AudioCache::readDataTask(unsigned int selfId)
             uint32_t framesRead = 0;
             const uint32_t framesToReadOnce = (std::min)(totalFrames, static_cast<uint32_t>(sampleRate * QUEUEBUFFER_TIME_STEP * QUEUEBUFFER_NUM));
 
-            std::vector<char> adjustFrameBuf;
-
-            if (decoder->seek(totalFrames))
-            {
-                char* tmpBuf = (char*)malloc(framesToReadOnce * bytesPerFrame);
-                adjustFrameBuf.reserve(framesToReadOnce * bytesPerFrame);
-
-                // Adjust total frames by setting position to the end of frames and try to read more data.
-                // This is a workaround for https://github.com/cocos2d/cocos2d-x/issues/16938
-                do
-                {
-                    framesRead = decoder->read(framesToReadOnce, tmpBuf);
-                    if (framesRead > 0)
-                    {
-                        adjustFrames += framesRead;
-                        adjustFrameBuf.insert(adjustFrameBuf.end(), tmpBuf, tmpBuf + framesRead * bytesPerFrame);
-                    }
-
-                } while (framesRead > 0);
-
-                if (adjustFrames > 0)
-                {
-                    ALOGV("Orignal total frames: %u, adjust frames: %u, current total frames: %u", totalFrames, adjustFrames, totalFrames + adjustFrames);
-                    totalFrames += adjustFrames;
-                    _totalFrames = remainingFrames = totalFrames;
-                }
-
-                // Reset dataSize
-                dataSize = totalFrames * bytesPerFrame;
-
-                free(tmpBuf);
-            }
-            // Reset to frame 0
-            BREAK_IF_ERR_LOG(!decoder->seek(0), "AudioDecoder::seek(0) failed!");
-
             _pcmData = (char*)malloc(dataSize);
             memset(_pcmData, 0x00, dataSize);
-
-            if (adjustFrames > 0)
-            {
-                memcpy(_pcmData + (dataSize - adjustFrameBuf.size()), adjustFrameBuf.data(), adjustFrameBuf.size());
-            }
 
             alGenBuffers(1, &_alBufferId);
             auto alError = alGetError();

--- a/cocos/audio/include/AudioDecoderWav.h
+++ b/cocos/audio/include/AudioDecoderWav.h
@@ -1,7 +1,8 @@
 /****************************************************************************
  Copyright (c) 2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
- Copyright (c) 2018 HALX99.
+ Copyright (c) 2018-2019 HALX99.
+ Copyright (c) 2020 c4games.com.
 
  http://www.cocos2d-x.org
 


### PR DESCRIPTION
At non-apple platforms we use mpg123,ogg,wav decoder, so don't need workaround to adjust tail frame.