### PR TITLE
Improve audio decoder, add MSADPCM and IMA4 compress support

### DIFF
--- a/cocos/audio/AudioCache.cpp
+++ b/cocos/audio/AudioCache.cpp
@@ -50,8 +50,6 @@ unsigned int __idIndex = 0;
 #define INVALID_AL_BUFFER_ID 0xFFFFFFFF
 #define PCMDATA_CACHEMAXSIZE 1048576
 
-#define CC_ALIGN(d, a) (((d) + ((a)-1)) & ~((a)-1))
-
 using namespace cocos2d;
 
 AudioCache::AudioCache()

--- a/cocos/audio/AudioDecoder.cpp
+++ b/cocos/audio/AudioDecoder.cpp
@@ -34,7 +34,7 @@ namespace cocos2d {
 AudioDecoder::AudioDecoder()
     : _isOpened(false)
     , _totalFrames(0)
-    , _bitsPerFrame(0)
+    , _bytesPerFrame(0)
     , _sampleRate(0)
     , _channelCount(0)
     , _sourceFormat(AUDIO_SOURCE_FORMAT::PCM_16)
@@ -58,13 +58,13 @@ AudioDecoder::AudioDecoder()
         uint32_t framesReadOnce = 0;
         do
         {
-            framesReadOnce = read(framesToRead - framesRead, pcmBuf + ((framesRead * _bitsPerFrame) >> 3));
+            framesReadOnce = read(framesToRead - framesRead, pcmBuf + ((framesRead * _bytesPerFrame)));
             framesRead += framesReadOnce;
         } while (framesReadOnce != 0 && framesRead < framesToRead);
 
         if (framesRead < framesToRead)
         {
-            memset(pcmBuf + ((framesRead * _bitsPerFrame) >> 3), 0x00, (((framesToRead - framesRead) * _bitsPerFrame)) >> 3);
+            memset(pcmBuf + ((framesRead * _bytesPerFrame)), 0x00, (((framesToRead - framesRead) * _bytesPerFrame)));
         }
 
         return framesRead;
@@ -75,9 +75,9 @@ AudioDecoder::AudioDecoder()
         return _totalFrames;
     }
 
-    uint32_t AudioDecoder::getBitsPerFrame() const
+    uint32_t AudioDecoder::framesToBytes(uint32_t frames) const
     {
-        return _bitsPerFrame;
+        return _bytesPerFrame * frames;
     }
 
     uint32_t AudioDecoder::getSampleRate() const

--- a/cocos/audio/AudioDecoder.cpp
+++ b/cocos/audio/AudioDecoder.cpp
@@ -34,7 +34,8 @@ namespace cocos2d {
 AudioDecoder::AudioDecoder()
     : _isOpened(false)
     , _totalFrames(0)
-    , _bytesPerFrame(0)
+    , _bytesPerBlock(0)
+    , _samplesPerBlock(1)
     , _sampleRate(0)
     , _channelCount(0)
     , _sourceFormat(AUDIO_SOURCE_FORMAT::PCM_16)
@@ -58,13 +59,13 @@ AudioDecoder::AudioDecoder()
         uint32_t framesReadOnce = 0;
         do
         {
-            framesReadOnce = read(framesToRead - framesRead, pcmBuf + ((framesRead * _bytesPerFrame)));
+            framesReadOnce = read(framesToRead - framesRead, pcmBuf + framesToBytes((framesRead)));
             framesRead += framesReadOnce;
         } while (framesReadOnce != 0 && framesRead < framesToRead);
 
         if (framesRead < framesToRead)
         {
-            memset(pcmBuf + ((framesRead * _bytesPerFrame)), 0x00, (((framesToRead - framesRead) * _bytesPerFrame)));
+            memset(pcmBuf + framesToBytes(framesRead), 0x0, framesToBytes(framesToRead - framesRead));
         }
 
         return framesRead;
@@ -77,7 +78,12 @@ AudioDecoder::AudioDecoder()
 
     uint32_t AudioDecoder::framesToBytes(uint32_t frames) const
     {
-        return _bytesPerFrame * frames;
+        return _bytesPerBlock * frames;
+    }
+
+    uint32_t AudioDecoder::bytesToFrames(uint32_t bytes) const
+    {
+        return bytes / _bytesPerBlock;
     }
 
     uint32_t AudioDecoder::getSampleRate() const
@@ -90,9 +96,13 @@ AudioDecoder::AudioDecoder()
         return _channelCount;
     }
 
+    uint32_t AudioDecoder::getSamplesPerBlock() const
+    {
+        return _samplesPerBlock;
+    }
+
     AUDIO_SOURCE_FORMAT AudioDecoder::getSourceFormat() const
     {
         return _sourceFormat;
     }
-
 }

--- a/cocos/audio/AudioDecoderMp3.cpp
+++ b/cocos/audio/AudioDecoderMp3.cpp
@@ -130,12 +130,12 @@ namespace cocos2d {
 
             if (mp3Encoding == MPG123_ENC_SIGNED_16)
             {
-                _bytesPerFrame = 2 * _channelCount;
+                _bytesPerBlock = 2 * _channelCount;
                 _sourceFormat = AUDIO_SOURCE_FORMAT::PCM_16;
             }
             else if (mp3Encoding == MPG123_ENC_FLOAT_32)
             {
-                _bytesPerFrame = 4 * _channelCount;
+                _bytesPerBlock = 4 * _channelCount;
                 _sourceFormat = AUDIO_SOURCE_FORMAT::PCM_FLT32;
             }
             else
@@ -181,7 +181,7 @@ namespace cocos2d {
 
     uint32_t AudioDecoderMp3::read(uint32_t framesToRead, char* pcmBuf)
     {
-        int bytesToRead = (framesToRead * _bytesPerFrame);
+        int bytesToRead = framesToBytes(framesToRead);
         size_t bytesRead = 0;
         int err = mpg123_read(_mpg123handle, (unsigned char*)pcmBuf, bytesToRead, &bytesRead);
         if (err == MPG123_ERR)
@@ -190,7 +190,7 @@ namespace cocos2d {
             return 0;
         }
 
-        return static_cast<uint32_t>((bytesRead) / _bytesPerFrame);
+        return bytesToFrames(bytesRead);
     }
 
     bool AudioDecoderMp3::seek(uint32_t frameOffset)
@@ -203,10 +203,4 @@ namespace cocos2d {
         }
         return false;
     }
-
-    uint32_t AudioDecoderMp3::tell() const
-    {
-        return static_cast<uint32_t>(mpg123_tell(_mpg123handle));
-    }
-
 } // namespace cocos2d {

--- a/cocos/audio/AudioDecoderMp3.cpp
+++ b/cocos/audio/AudioDecoderMp3.cpp
@@ -130,12 +130,12 @@ namespace cocos2d {
 
             if (mp3Encoding == MPG123_ENC_SIGNED_16)
             {
-                _bitsPerFrame = (_channelCount << 4); // 2 * 8
+                _bytesPerFrame = 2 * _channelCount;
                 _sourceFormat = AUDIO_SOURCE_FORMAT::PCM_16;
             }
             else if (mp3Encoding == MPG123_ENC_FLOAT_32)
             {
-                _bitsPerFrame = (_channelCount << 5); // 4 * 8
+                _bytesPerFrame = 4 * _channelCount;
                 _sourceFormat = AUDIO_SOURCE_FORMAT::PCM_FLT32;
             }
             else
@@ -181,7 +181,7 @@ namespace cocos2d {
 
     uint32_t AudioDecoderMp3::read(uint32_t framesToRead, char* pcmBuf)
     {
-        int bytesToRead = (framesToRead * _bitsPerFrame) >> 3;
+        int bytesToRead = (framesToRead * _bytesPerFrame);
         size_t bytesRead = 0;
         int err = mpg123_read(_mpg123handle, (unsigned char*)pcmBuf, bytesToRead, &bytesRead);
         if (err == MPG123_ERR)
@@ -190,7 +190,7 @@ namespace cocos2d {
             return 0;
         }
 
-        return static_cast<uint32_t>((bytesRead << 3 ) / _bitsPerFrame);
+        return static_cast<uint32_t>((bytesRead) / _bytesPerFrame);
     }
 
     bool AudioDecoderMp3::seek(uint32_t frameOffset)

--- a/cocos/audio/AudioDecoderOgg.cpp
+++ b/cocos/audio/AudioDecoderOgg.cpp
@@ -88,7 +88,7 @@ namespace cocos2d {
             vorbis_info* vi = ov_info(&_vf, -1);
             _sampleRate = static_cast<uint32_t>(vi->rate);
             _channelCount = vi->channels;
-            _bytesPerFrame = vi->channels * sizeof(short);
+            _bytesPerBlock = vi->channels * sizeof(short);
             _totalFrames = static_cast<uint32_t>(ov_pcm_total(&_vf, -1));
             _isOpened = true;
             return true;
@@ -108,19 +108,13 @@ namespace cocos2d {
     uint32_t AudioDecoderOgg::read(uint32_t framesToRead, char* pcmBuf)
     {
         int currentSection = 0;
-        int bytesToRead = (framesToRead * _bytesPerFrame);
+        int bytesToRead = framesToBytes(framesToRead);
         long bytesRead = ov_read(&_vf, pcmBuf, bytesToRead, 0, 2, 1, &currentSection);
-        return static_cast<uint32_t>((bytesRead) / _bytesPerFrame);
+        return bytesToFrames(bytesRead);
     }
 
     bool AudioDecoderOgg::seek(uint32_t frameOffset)
     {
         return 0 == ov_pcm_seek(&_vf, frameOffset);
     }
-
-    uint32_t AudioDecoderOgg::tell() const
-    {
-        return static_cast<uint32_t>(ov_pcm_tell(const_cast<OggVorbis_File*>(&_vf)));
-    }
-
 } // namespace cocos2d {

--- a/cocos/audio/AudioDecoderOgg.cpp
+++ b/cocos/audio/AudioDecoderOgg.cpp
@@ -37,7 +37,6 @@
 
 namespace cocos2d {
 
-
     static size_t ov_fread_r(void* buffer, size_t element_size, size_t element_count, void* handle)
     {
         return ((PXFileStream*)handle)->read(buffer, static_cast<uint32_t>(element_size * element_count));
@@ -89,7 +88,7 @@ namespace cocos2d {
             vorbis_info* vi = ov_info(&_vf, -1);
             _sampleRate = static_cast<uint32_t>(vi->rate);
             _channelCount = vi->channels;
-            _bitsPerFrame = (vi->channels << 4); // 2 * 8
+            _bytesPerFrame = vi->channels * sizeof(short);
             _totalFrames = static_cast<uint32_t>(ov_pcm_total(&_vf, -1));
             _isOpened = true;
             return true;
@@ -109,9 +108,9 @@ namespace cocos2d {
     uint32_t AudioDecoderOgg::read(uint32_t framesToRead, char* pcmBuf)
     {
         int currentSection = 0;
-        int bytesToRead = (framesToRead * _bitsPerFrame) >> 3;
+        int bytesToRead = (framesToRead * _bytesPerFrame);
         long bytesRead = ov_read(&_vf, pcmBuf, bytesToRead, 0, 2, 1, &currentSection);
-        return static_cast<uint32_t>((bytesRead << 3) / _bitsPerFrame);
+        return static_cast<uint32_t>((bytesRead) / _bytesPerFrame);
     }
 
     bool AudioDecoderOgg::seek(uint32_t frameOffset)

--- a/cocos/audio/AudioPlayer.cpp
+++ b/cocos/audio/AudioPlayer.cpp
@@ -251,6 +251,7 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
         uint32_t framesRead = 0;
         const uint32_t framesToRead = _audioCache->_queBufferFrames;
         const uint32_t bufferSize = decoder->framesToBytes(framesToRead);
+        const auto sourceFormat = decoder->getSourceFormat();
         tmpBuffer = (char*)malloc(bufferSize);
         memset(tmpBuffer, 0, bufferSize);
 
@@ -298,6 +299,8 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
 
                     ALuint bid;
                     alSourceUnqueueBuffers(_alSource, 1, &bid);
+                    if (sourceFormat == AUDIO_SOURCE_FORMAT::ADPCM || sourceFormat == AUDIO_SOURCE_FORMAT::IMA_ADPCM)
+                        alBufferi(bid, AL_UNPACK_BLOCK_ALIGNMENT_SOFT, decoder->getSamplesPerBlock());
                     alBufferData(bid, _audioCache->_format, tmpBuffer, decoder->framesToBytes(framesRead), decoder->getSampleRate());
                     alSourceQueueBuffers(_alSource, 1, &bid);
                 }

--- a/cocos/audio/AudioPlayer.cpp
+++ b/cocos/audio/AudioPlayer.cpp
@@ -250,7 +250,7 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
 
         uint32_t framesRead = 0;
         const uint32_t framesToRead = _audioCache->_queBufferFrames;
-        const uint32_t bufferSize = (framesToRead * decoder->getBitsPerFrame()) >> 3;
+        const uint32_t bufferSize = decoder->framesToBytes(framesToRead);
         tmpBuffer = (char*)malloc(bufferSize);
         memset(tmpBuffer, 0, bufferSize);
 
@@ -298,7 +298,7 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
 
                     ALuint bid;
                     alSourceUnqueueBuffers(_alSource, 1, &bid);
-                    alBufferData(bid, _audioCache->_format, tmpBuffer, (framesRead * decoder->getBitsPerFrame()) >> 3, decoder->getSampleRate());
+                    alBufferData(bid, _audioCache->_format, tmpBuffer, decoder->framesToBytes(framesRead), decoder->getSampleRate());
                     alSourceQueueBuffers(_alSource, 1, &bid);
                 }
             }

--- a/cocos/audio/apple/AudioDecoderEXT.h
+++ b/cocos/audio/apple/AudioDecoderEXT.h
@@ -58,7 +58,7 @@ public:
     /**
      * @brief Reads audio frames of PCM format.
      * @param framesToRead The number of frames excepted to be read.
-     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| * _bytesPerFrame.
+     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| / samplesPerBlock * _bytesPerBlock.
      * @return The number of frames actually read, it's probably less than 'framesToRead'. Returns 0 means reach the end of file.
      */
     uint32_t read(uint32_t framesToRead, char* pcmBuf) override;
@@ -66,7 +66,7 @@ public:
     /**
      * @brief Reads fixed audio frames of PCM format.
      * @param framesToRead The number of frames excepted to be read.
-     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| * _bytesPerFrame.
+     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| / samplesPerBlock * _bytesPerBlock.
      * @return The number of frames actually read, it's probably less than |framesToRead|. Returns 0 means reach the end of file.
      * @note The different between |read| and |readFixedFrames| is |readFixedFrames| will do multiple reading operations if |framesToRead| frames
      *       isn't filled entirely, while |read| just does reading operation once whatever |framesToRead| is or isn't filled entirely.
@@ -81,12 +81,6 @@ public:
      * @return true if succeed, otherwise false
      */
     bool seek(uint32_t frameOffset) override;
-
-    /**
-     * @brief Tells the current frame offset.
-     * @return The current frame offset.
-     */
-    uint32_t tell() const override;
 
 private:
     ExtAudioFileRef _extRef;

--- a/cocos/audio/apple/AudioDecoderEXT.mm
+++ b/cocos/audio/apple/AudioDecoderEXT.mm
@@ -79,10 +79,10 @@ namespace cocos2d {
 
             _sampleRate = _outputFormat.mSampleRate;
             _channelCount = _outputFormat.mChannelsPerFrame;
-            _bytesPerFrame = 2 * _outputFormat.mChannelsPerFrame;
+            _bytesPerBlock = 2 * _outputFormat.mChannelsPerFrame;
 
-            _outputFormat.mBytesPerPacket = _bytesPerFrame;
-            _outputFormat.mBytesPerFrame = _bytesPerFrame;
+            _outputFormat.mBytesPerPacket = _bytesPerBlock;
+            _outputFormat.mBytesPerFrame = _bytesPerBlock;
 
             status = ExtAudioFileSetProperty(_extRef, kExtAudioFileProperty_ClientDataFormat, sizeof(_outputFormat), &_outputFormat);
             BREAK_IF_ERR_LOG(status != noErr, "ExtAudioFileSetProperty FAILED, Error = %d", (int)status);
@@ -131,7 +131,7 @@ namespace cocos2d {
 
             AudioBufferList bufferList;
             bufferList.mNumberBuffers = 1;
-            bufferList.mBuffers[0].mDataByteSize = framesToRead * _bytesPerFrame;
+            bufferList.mBuffers[0].mDataByteSize = framesToRead * _bytesPerBlock;
             bufferList.mBuffers[0].mNumberChannels = _outputFormat.mChannelsPerFrame;
             bufferList.mBuffers[0].mData = pcmBuf;
 
@@ -158,20 +158,4 @@ namespace cocos2d {
         } while(false);
         return ret;
     }
-
-    uint32_t AudioDecoderEXT::tell() const
-    {
-        uint32_t ret = INVALID_FRAME_INDEX;
-        do
-        {
-            BREAK_IF_ERR_LOG(!isOpened(), "decoder isn't openned");
-            SInt64 frameIndex = INVALID_FRAME_INDEX;
-            OSStatus status = ExtAudioFileTell(_extRef, &frameIndex);
-            BREAK_IF(status != noErr);
-            ret = static_cast<uint32_t>(frameIndex);
-        } while(false);
-
-        return ret;
-    }
-
 } // namespace cocos2d {

--- a/cocos/audio/apple/AudioPlayer.mm
+++ b/cocos/audio/apple/AudioPlayer.mm
@@ -270,7 +270,7 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
 
         uint32_t framesRead = 0;
         const uint32_t framesToRead = _audioCache->_queBufferFrames;
-        const uint32_t bufferSize = framesToRead * decoder->getBytesPerFrame();
+        const uint32_t bufferSize = decoder->framesToBytes(framesToRead);
         tmpBuffer = (char*)malloc(bufferSize);
         memset(tmpBuffer, 0, bufferSize);
 
@@ -323,7 +323,7 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
                      */
                     ALuint bid;
                     alSourceUnqueueBuffers(_alSource, 1, &bid);
-                    alBufferData(bid, _audioCache->_format, tmpBuffer, framesRead * decoder->getBytesPerFrame(), decoder->getSampleRate());
+                    alBufferData(bid, _audioCache->_format, tmpBuffer, decoder->framesToBytes(framesRead), decoder->getSampleRate());
                     alSourceQueueBuffers(_alSource, 1, &bid);
                 }
             }

--- a/cocos/audio/include/AudioDecoder.h
+++ b/cocos/audio/include/AudioDecoder.h
@@ -74,7 +74,7 @@ public:
     /**
      * @brief Reads audio frames of PCM format.
      * @param framesToRead The number of frames excepted to be read.
-     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| * _bytesPerFrame.
+     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| / samplesPerBlock * _bytesPerBlock.
      * @return The number of frames actually read, it's probably less than 'framesToRead'. Returns 0 means reach the end of file.
      */
     virtual uint32_t read(uint32_t framesToRead, char* pcmBuf) = 0;
@@ -82,7 +82,7 @@ public:
     /**
      * @brief Reads fixed audio frames of PCM format.
      * @param framesToRead The number of frames excepted to be read.
-     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| * _bytesPerFrame.
+     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| / samplesPerBlock * _bytesPerBlock.
      * @return The number of frames actually read, it's probably less than |framesToRead|. Returns 0 means reach the end of file.
      * @note The different between |read| and |readFixedFrames| is |readFixedFrames| will do multiple reading operations if |framesToRead| frames
      *       isn't filled entirely, while |read| just does reading operation once whatever |framesToRead| is or isn't filled entirely.
@@ -98,17 +98,18 @@ public:
      */
     virtual bool seek(uint32_t frameOffset) = 0;
 
-    /**
-     * @brief Tells the current frame offset.
-     * @return The current frame offset.
-     */
-    virtual uint32_t tell() const = 0;
-
     /** Gets total frames of current audio.*/
     virtual uint32_t getTotalFrames() const;
 
-    /** Gets bytes per frame of current audio.*/
+    /**
+    * @brief The helper function for convert frames to bytes
+    */
     virtual uint32_t framesToBytes(uint32_t frames) const;
+
+    /**
+    * @brief The helper function for convert bytes to frames
+    */
+    virtual uint32_t bytesToFrames(uint32_t bytes) const;
 
     /** Gets sample rate of current audio.*/
     virtual uint32_t getSampleRate() const;
@@ -118,6 +119,11 @@ public:
      */
     virtual uint32_t getChannelCount() const;
 
+    /*
+    * @brief Gets samples per block, usually is 1 for .mp3 or .ogg, .wav may > 1
+    */
+    uint32_t getSamplesPerBlock() const;
+
     virtual AUDIO_SOURCE_FORMAT getSourceFormat() const;
 
 protected:
@@ -126,7 +132,8 @@ protected:
 
     bool _isOpened;
     uint32_t _totalFrames;
-    uint32_t _bytesPerFrame;
+    uint32_t _bytesPerBlock; // Same as bytesPerFrame when _samplesPerBlock is 1
+    uint32_t _samplesPerBlock;
     uint32_t _sampleRate;
     uint32_t _channelCount;
     AUDIO_SOURCE_FORMAT _sourceFormat;

--- a/cocos/audio/include/AudioDecoder.h
+++ b/cocos/audio/include/AudioDecoder.h
@@ -108,7 +108,7 @@ public:
     virtual uint32_t getTotalFrames() const;
 
     /** Gets bytes per frame of current audio.*/
-    virtual uint32_t getBitsPerFrame() const;
+    virtual uint32_t framesToBytes(uint32_t frames) const;
 
     /** Gets sample rate of current audio.*/
     virtual uint32_t getSampleRate() const;
@@ -126,7 +126,7 @@ protected:
 
     bool _isOpened;
     uint32_t _totalFrames;
-    uint32_t _bitsPerFrame;
+    uint32_t _bytesPerFrame;
     uint32_t _sampleRate;
     uint32_t _channelCount;
     AUDIO_SOURCE_FORMAT _sourceFormat;

--- a/cocos/audio/include/AudioDecoderMp3.h
+++ b/cocos/audio/include/AudioDecoderMp3.h
@@ -42,34 +42,28 @@ public:
      * @brief Opens an audio file specified by a file path.
      * @return true if succeed, otherwise false.
      */
-    virtual bool open(const std::string& path) override;
+    bool open(const std::string& path) override;
 
     /**
      * @brief Closes opened audio file.
      * @note The method will also be automatically invoked in the destructor.
      */
-    virtual void close() override;
+    void close() override;
 
     /**
      * @brief Reads audio frames of PCM format.
      * @param framesToRead The number of frames excepted to be read.
-     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| * _bytesPerFrame.
+     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| / samplesPerBlock * _bytesPerBlock.
      * @return The number of frames actually read, it's probably less than 'framesToRead'. Returns 0 means reach the end of file.
      */
-    virtual uint32_t read(uint32_t framesToRead, char* pcmBuf) override;
+    uint32_t read(uint32_t framesToRead, char* pcmBuf) override;
 
     /**
      * @brief Sets frame offest to be read.
      * @param frameOffset The frame offest to be set.
      * @return true if succeed, otherwise false
      */
-    virtual bool seek(uint32_t frameOffset) override;
-
-    /**
-     * @brief Tells the current frame offset.
-     * @return The current frame offset.
-     */
-    virtual uint32_t tell() const override;
+    bool seek(uint32_t frameOffset) override;
 
 protected:
 

--- a/cocos/audio/include/AudioDecoderOgg.h
+++ b/cocos/audio/include/AudioDecoderOgg.h
@@ -43,34 +43,28 @@ public:
      * @brief Opens an audio file specified by a file path.
      * @return true if succeed, otherwise false.
      */
-    virtual bool open(const std::string& path) override;
+    bool open(const std::string& path) override;
 
     /**
      * @brief Closes opened audio file.
      * @note The method will also be automatically invoked in the destructor.
      */
-    virtual void close() override;
+    void close() override;
 
     /**
      * @brief Reads audio frames of PCM format.
      * @param framesToRead The number of frames excepted to be read.
-     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| * _bytesPerFrame.
+     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| / samplesPerBlock * _bytesPerBlock.
      * @return The number of frames actually read, it's probably less than 'framesToRead'. Returns 0 means reach the end of file.
      */
-    virtual uint32_t read(uint32_t framesToRead, char* pcmBuf) override;
+    uint32_t read(uint32_t framesToRead, char* pcmBuf) override;
 
     /**
      * @brief Sets frame offest to be read.
      * @param frameOffset The frame offest to be set.
      * @return true if succeed, otherwise false
      */
-    virtual bool seek(uint32_t frameOffset) override;
-
-    /**
-     * @brief Tells the current frame offset.
-     * @return The current frame offset.
-     */
-    virtual uint32_t tell() const override;
+    bool seek(uint32_t frameOffset) override;
 
 protected:
     AudioDecoderOgg();

--- a/cocos/audio/include/AudioDecoderWav.h
+++ b/cocos/audio/include/AudioDecoderWav.h
@@ -107,8 +107,6 @@ struct WAV_FILE
     WAV_FILE_HEADER FileHeader;
     AUDIO_SOURCE_FORMAT SourceFormat;
     uint32_t PcmDataOffset;
-    uint32_t BitsPerFrame;
-
     cocos2d::PXFileStream Stream;
 };
 
@@ -123,51 +121,46 @@ public:
      * @brief Opens an audio file specified by a file path.
      * @return true if succeed, otherwise false.
      */
-    virtual bool open(const std::string& path) override;
+    bool open(const std::string& path) override;
 
+    /**
+    * @brief The helper function for convert frames to bytes
+    */
     uint32_t framesToBytes(uint32_t frames) const override;
 
-    uint32_t bytesToFrames(uint32_t bytes) const;
+    /**
+    * @brief The helper function for convert bytes to frames
+    */
+    uint32_t bytesToFrames(uint32_t bytes) const override;
 
     /**
      * @brief Closes opened audio file.
      * @note The method will also be automatically invoked in the destructor.
      */
-    virtual void close() override;
+    void close() override;
 
     /**
      * @brief Reads audio frames of PCM format.
      * @param framesToRead The number of frames excepted to be read.
-     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| * _bytesPerFrame.
+     * @param pcmBuf The buffer to hold the frames to be read, its size should be >= |framesToRead| / samplesPerBlock * _bytesPerBlock.
      * @return The number of frames actually read, it's probably less than 'framesToRead'. Returns 0 means reach the end of file.
      */
-    virtual uint32_t read(uint32_t framesToRead, char* pcmBuf) override;
+    uint32_t read(uint32_t framesToRead, char* pcmBuf) override;
 
     /**
      * @brief Sets frame offest to be read.
      * @param frameOffset The frame offest to be set.
      * @return true if succeed, otherwise false
      */
-    virtual bool seek(uint32_t frameOffset) override;
-
-    /**
-     * @brief Tells the current frame offset.
-     * @return The current frame offset.
-     */
-    virtual uint32_t tell() const override;
-
-    /**
-    * @brief helpers function fo frames alignment when bytesPerFrame < 1
-    */
-    uint32_t getBytesPerBlock() const;
-    uint32_t getSamplesPerBlock() const;
+    bool seek(uint32_t frameOffset) override;
 
 protected:
+
+    friend class AudioDecoderManager;
     AudioDecoderWav();
     ~AudioDecoderWav();
 
     mutable WAV_FILE _wavf;
-    friend class AudioDecoderManager;
 };
 
 } // namespace cocos2d {

--- a/cocos/audio/include/AudioDecoderWav.h
+++ b/cocos/audio/include/AudioDecoderWav.h
@@ -125,6 +125,10 @@ public:
      */
     virtual bool open(const std::string& path) override;
 
+    uint32_t framesToBytes(uint32_t frames) const override;
+
+    uint32_t bytesToFrames(uint32_t bytes) const;
+
     /**
      * @brief Closes opened audio file.
      * @note The method will also be automatically invoked in the destructor.
@@ -151,6 +155,12 @@ public:
      * @return The current frame offset.
      */
     virtual uint32_t tell() const override;
+
+    /**
+    * @brief helpers function fo frames alignment when bytesPerFrame < 1
+    */
+    uint32_t getBytesPerBlock() const;
+    uint32_t getSamplesPerBlock() const;
 
 protected:
     AudioDecoderWav();


### PR DESCRIPTION
1. Add wav MSADPCM and IMA4 compress format support [it's supported by OpenAL]
2. Remove unused interface ```AudioDecoder::tell```