### PR TITLE
Update download-deps.py

### DIFF
--- a/download-deps.py
+++ b/download-deps.py
@@ -44,6 +44,7 @@ import traceback
 import distutils
 import fileinput
 import json
+import ssl
 
 from optparse import OptionParser
 from time import time
@@ -350,6 +351,7 @@ def _check_python_version():
 
 
 def main():
+    ssl._create_default_https_context = ssl._create_unverified_context
     workpath = os.path.dirname(os.path.realpath(__file__))
 
     if not _check_python_version():


### PR DESCRIPTION
Fix for URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:727)> error on mac osx