### PR TITLE
fix ios readme build device description

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
   ```sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer```  
   3. Generate xcode project
   ```sh
-    # for device arm64
+    # for any device
     cmake -S . -B build -GXcode -DCMAKE_TOOLCHAIN_FILE=cmake/ios.mini.cmake
 
     # for device combined armv7,arm64


### PR DESCRIPTION
if none arch has been defined,then you can use "xcodebuild  -scheme "lua-empty-test" -sdk  iphonesimulator SYMROOT=." to compile the simulator ,or,You can use 'xcodebuild  -scheme "lua-empty-test" -sdk  iphoneos SYMROOT=.' to build in ios device。
The Xcode Architectures will show "Standard architecture"