### PR TITLE
Update cocos.bat

### DIFF
--- a/tools/cocos2d-console/bin/cocos.bat
+++ b/tools/cocos2d-console/bin/cocos.bat
@@ -1,3 +1,3 @@
 @echo off
-@python "%~dp0/cocos.py" %*
+"%~dp0/cocos.py" %*
 


### PR DESCRIPTION
I got always:
Python was not found; run without arguments to install from the Microsoft Store, or disable this shortcut from Settings > Manage App Execution Aliases.

Normaly "Python.exe" is on the path variable too. and will be found.
=> Works now with removed "@python".


