### PR TITLE
Fix ListView dimensions when child elements are scaled

### DIFF
--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -117,7 +117,7 @@ void ListView::updateInnerContainerSize()
             float totalHeight = (length == 0) ? 0.0f : (length - 1) * _itemsMargin + (_topPadding + _bottomPadding);
             for (auto& item : _items)
             {
-                totalHeight += item->getContentSize().height;
+                totalHeight += item->getContentSize().height * item->getScaleY();
             }
             float finalWidth = _contentSize.width;
             float finalHeight = totalHeight;
@@ -130,7 +130,7 @@ void ListView::updateInnerContainerSize()
             float totalWidth = (length == 0) ? 0.0f : (length - 1) * _itemsMargin + (_leftPadding + _rightPadding);
             for (auto& item : _items)
             {
-                totalWidth += item->getContentSize().width;
+                totalWidth += item->getContentSize().width * item->getScaleX();
             }
             float finalWidth = totalWidth;
             float finalHeight = _contentSize.height;


### PR DESCRIPTION
If a ListView has items that are scaled, then the ListView dimensions are not correctly set based on the size of those items, so some of the items cannot be scrolled to.  More info [here](https://github.com/cocos2d/cocos2d-x/issues/20431)