### PR TITLE
Refactor android runOnGLThread

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -217,10 +217,10 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
         msg.obj = new Cocos2dxHandler.DialogMessage(pTitle, pMessage);
         this.mHandler.sendMessage(msg);
     }
-    
-    @Override
-    public void runOnGLThread(final Runnable pRunnable) {
-        this.mGLSurfaceView.queueEvent(pRunnable);
+
+    @Deprecated
+    public void runOnGLThread(final Runnable runnable) {
+        Cocos2dxHelper.runOnGLThread(runnable);
     }
     
     @Override

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -130,7 +130,7 @@ public class Cocos2dxEditBoxHelper {
                     public void afterTextChanged(final Editable s) {
                         if (!editBox.getChangedTextProgrammatically()) {
                             if ((Boolean) editBox.getTag()) {
-                                mCocos2dxActivity.runOnGLThread(new Runnable() {
+                                Cocos2dxHelper.runOnGLThread(new Runnable() {
                                     @Override
                                     public void run() {
                                         Cocos2dxEditBoxHelper.__editBoxEditingChanged(index, s.toString());
@@ -152,7 +152,7 @@ public class Cocos2dxEditBoxHelper {
                         editBox.setTag(true);
                         editBox.setChangedTextProgrammatically(false);
                         if (hasFocus) {
-                            mCocos2dxActivity.runOnGLThread(new Runnable() {
+                            Cocos2dxHelper.runOnGLThread(new Runnable() {
                                 @Override
                                 public void run() {
                                     editBox.endAction = Cocos2dxEditBox.kEndActionUnknown;
@@ -168,7 +168,7 @@ public class Cocos2dxEditBoxHelper {
                             // Note that we must to copy a string to prevent string content is modified
                             // on UI thread while 's.toString' is invoked at the same time.
                             final String text = new String(editBox.getText().toString());
-                            mCocos2dxActivity.runOnGLThread(new Runnable() {
+                            Cocos2dxHelper.runOnGLThread(new Runnable() {
                                 @Override
                                 public void run() {
                                     int action = editBox.endAction;

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -111,7 +111,7 @@ public class Cocos2dxHelper {
     // ===========================================================
 
     public static void runOnGLThread(final Runnable r) {
-        ((Cocos2dxActivity)sActivity).runOnGLThread(r);
+        nativeRunOnGLThread(r);
     }
 
     private static boolean sInited = false;
@@ -264,6 +264,8 @@ public class Cocos2dxHelper {
     // Methods
     // ===========================================================
 
+    private static native void nativeRunOnGLThread(final Object runnable);
+
     private static native void nativeSetEditTextDialogResult(final byte[] pBytes);
 
     private static native void nativeSetContext(final Object pContext, final Object pAssetManager);
@@ -394,7 +396,7 @@ public class Cocos2dxHelper {
         try {
             final byte[] bytesUTF8 = pResult.getBytes("UTF8");
 
-            Cocos2dxHelper.sCocos2dxHelperListener.runOnGLThread(new Runnable() {
+            Cocos2dxHelper.runOnGLThread(new Runnable() {
                 @Override
                 public void run() {
                     Cocos2dxHelper.nativeSetEditTextDialogResult(bytesUTF8);
@@ -608,8 +610,6 @@ public class Cocos2dxHelper {
 
     public static interface Cocos2dxHelperListener {
         public void showDialog(final String pTitle, final String pMessage);
-
-        public void runOnGLThread(final Runnable pRunnable);
     }
 
     //Enhance API modification begin

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
@@ -33,6 +33,8 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 
+import org.cocos2dx.lib.Cocos2dxHelper;
+
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.concurrent.CountDownLatch;
@@ -109,7 +111,7 @@ public class Cocos2dxWebView extends WebView {
             try {
                 URI uri = URI.create(urlString);
                 if (uri != null && uri.getScheme().equals(mJSScheme)) {
-                    activity.runOnGLThread(new Runnable() {
+                    Cocos2dxHelper.runOnGLThread(new Runnable() {
                         @Override
                         public void run() {
                             Cocos2dxWebViewHelper._onJsCallback(mViewTag, urlString);
@@ -125,7 +127,7 @@ public class Cocos2dxWebView extends WebView {
             CountDownLatch latch = new CountDownLatch(1);
 
             // run worker on cocos thread
-            activity.runOnGLThread(new ShouldStartLoadingWorker(latch, result, mViewTag, urlString));
+            Cocos2dxHelper.runOnGLThread(new ShouldStartLoadingWorker(latch, result, mViewTag, urlString));
 
             // wait for result from cocos thread
             try {
@@ -140,8 +142,7 @@ public class Cocos2dxWebView extends WebView {
         @Override
         public void onPageFinished(WebView view, final String url) {
             super.onPageFinished(view, url);
-            Cocos2dxActivity activity = (Cocos2dxActivity)getContext();
-            activity.runOnGLThread(new Runnable() {
+            Cocos2dxHelper.runOnGLThread(new Runnable() {
                 @Override
                 public void run() {
                     Cocos2dxWebViewHelper._didFinishLoading(mViewTag, url);
@@ -153,7 +154,7 @@ public class Cocos2dxWebView extends WebView {
         public void onReceivedError(WebView view, int errorCode, String description, final String failingUrl) {
             super.onReceivedError(view, errorCode, description, failingUrl);
             Cocos2dxActivity activity = (Cocos2dxActivity)getContext();
-            activity.runOnGLThread(new Runnable() {
+            Cocos2dxHelper.runOnGLThread(new Runnable() {
                 @Override
                 public void run() {
                     Cocos2dxWebViewHelper._didFailLoading(mViewTag, failingUrl);

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -82,6 +82,23 @@ extern "C" {
         }
     }
 
+    JNIEXPORT void JNICALL Java_org_cocos2dx_lib_Cocos2dxHelper_nativeRunOnGLThread(JNIEnv* env, jclass, jobject runnable) {
+        using jobject_type = std::remove_pointer_t<jobject>;
+        struct jobject_delete {
+            void operator()(jobject_type* __ptr) const _NOEXCEPT {
+                JniHelper::getEnv()->DeleteGlobalRef(__ptr);
+            }
+        };
+
+        cocos2d::Director::getInstance()->getScheduler()->performFunctionInCocosThread([wrap = std::make_shared<std::unique_ptr<jobject_type, jobject_delete>>(env->NewGlobalRef(runnable))]{
+            auto curEnv = JniHelper::getEnv();
+
+            JniMethodInfo mi;
+            if(JniHelper::getMethodInfo(mi, "java/lang/Runnable", "run", "()V")){
+                curEnv->CallVoidMethod(wrap.get()->get(), mi.methodID);
+            }
+        });
+    }
 }
 
 const char * getApkPath() {


### PR DESCRIPTION
Ensure the callback run at engine core mainLoop,
This commit can solve any weird behaviors, such as:
a. text render maybe missing charactors when bring from back to frontend
b. some renderer objects alpha may present black at sdk callback call
c. some other things
All above behavior is caused gl state not ready when go back to game activity from sdk activity