### PR TITLE
Fix #313

### DIFF
--- a/cocos/renderer/backend/metal/DepthStencilStateMTL.mm
+++ b/cocos/renderer/backend/metal/DepthStencilStateMTL.mm
@@ -140,14 +140,14 @@ void DepthStencilStateMTL::update(const DepthStencilDescriptor& descriptor)
     
     MTLDepthStencilDescriptor* mtlDescriptor = [[MTLDepthStencilDescriptor alloc] init];
 
-    if (bitmask::any(descriptor.depthStencilFlags, TargetBufferFlags::DEPTH))
+    if (bitmask::any(descriptor.depthStencilFlags, TargetBufferFlags::DEPTH_AND_STENCIL))
         mtlDescriptor.depthCompareFunction = toMTLCompareFunction(descriptor.depthCompareFunction);
     else
         mtlDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
 
     mtlDescriptor.depthWriteEnabled = descriptor.depthWriteEnabled;
 
-    if (bitmask::any(descriptor.depthStencilFlags, TargetBufferFlags::STENCIL))
+    if (bitmask::any(descriptor.depthStencilFlags, TargetBufferFlags::DEPTH_AND_STENCIL))
     {
         setMTLStencilDescriptor(mtlDescriptor.frontFaceStencil, descriptor.frontFaceStencil);
         setMTLStencilDescriptor(mtlDescriptor.backFaceStencil, descriptor.backFaceStencil);

--- a/cocos/renderer/backend/metal/RenderPipelineMTL.mm
+++ b/cocos/renderer/backend/metal/RenderPipelineMTL.mm
@@ -305,8 +305,8 @@ void RenderPipelineMTL::chooseAttachmentFormat(const RenderTarget* renderTarget,
     }
     
     // choose depth and stencil attachment format, match RenderTargetMTL::applyRenderPassAttachments
-    depthFormat = bitmask::any(rtflags, RenderTargetFlag::DEPTH) ? rtMTL->getDepthAttachmentPixelFormat() : PixelFormat::NONE;
-    stencilFormat = bitmask::any(rtflags, RenderTargetFlag::STENCIL) ? rtMTL->getStencilAttachmentPixelFormat() : PixelFormat::NONE;
+    depthFormat = bitmask::any(rtflags, RenderTargetFlag::DEPTH_AND_STENCIL) ? rtMTL->getDepthAttachmentPixelFormat() : PixelFormat::NONE;
+    stencilFormat = bitmask::any(rtflags, RenderTargetFlag::DEPTH_AND_STENCIL) ? rtMTL->getStencilAttachmentPixelFormat() : PixelFormat::NONE;
 }
 
 void RenderPipelineMTL::setBlendStateAndFormat(const BlendDescriptor& blendDescriptor)

--- a/cocos/renderer/backend/metal/RenderTargetMTL.mm
+++ b/cocos/renderer/backend/metal/RenderTargetMTL.mm
@@ -97,7 +97,7 @@ void RenderTargetMTL::applyRenderPassAttachments(const RenderPassParams& params,
     }
     
     // Sets descriptor depth and stencil params, should match RenderTargetMTL::chooseAttachmentFormat
-    if(bitmask::any(this->_flags, RenderTargetFlag::DEPTH)) {
+    if(bitmask::any(this->_flags, RenderTargetFlag::DEPTH_AND_STENCIL)) {
         auto depthAttachment = getDepthAttachment();
         if(depthAttachment){
             descriptor.depthAttachment.texture = depthAttachment.texture;
@@ -109,7 +109,7 @@ void RenderTargetMTL::applyRenderPassAttachments(const RenderPassParams& params,
         }
     }
     
-    if(bitmask::any(this->_flags, RenderTargetFlag::STENCIL)) {
+    if(bitmask::any(this->_flags, RenderTargetFlag::DEPTH_AND_STENCIL)) {
         auto stencilAttachment = getStencilAttachment();
         if(stencilAttachment) {
             descriptor.stencilAttachment.texture = stencilAttachment.texture;
@@ -177,7 +177,7 @@ PixelFormat RenderTargetMTL::getColorAttachmentPixelFormat(int index) const
 
 PixelFormat RenderTargetMTL::getDepthAttachmentPixelFormat() const
 { // FIXME: engine-x only support D24S8
-    if(bitmask::any(_flags, TargetBufferFlags::DEPTH)) {
+    if(bitmask::any(_flags, TargetBufferFlags::DEPTH_AND_STENCIL)) {
         if(isDefaultRenderTarget() || !_depth)
             return PixelFormat::D24S8;
         return _depth.texture->getTextureFormat();
@@ -187,7 +187,7 @@ PixelFormat RenderTargetMTL::getDepthAttachmentPixelFormat() const
 
 PixelFormat RenderTargetMTL::getStencilAttachmentPixelFormat() const
 { // FIXME: engine-x only support D24S8
-    if(bitmask::any(_flags, TargetBufferFlags::STENCIL)) {
+    if(bitmask::any(_flags, TargetBufferFlags::DEPTH_AND_STENCIL)) {
         if(isDefaultRenderTarget() || !_stencil)
             return PixelFormat::D24S8;
         return _stencil.texture->getTextureFormat();


### PR DESCRIPTION
a. error: depthAttachment PixelFormat (MTLPixelFormatInvalid) and stencilAttachment PixelFormat (MTLPixelFormat Depth32Float_Stencil8) must match.
b. Because we only support D24S8(D32FS8) combined format, so needs check
TargetBuffferFlags::DEPTH_AND_STENCIL when setup depth and stencil
format, otherwise newRenderPipelineWithDescriptor will crash on some ios11 devices