### PR TITLE
Use unique_ptr for FileStream

### DIFF
--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -174,7 +174,7 @@ bool FontFreeType::createFontObject(const std::string &fontName, float fontSize)
         auto fullPath = FileUtils::getInstance()->fullPathForFilename(fontName);
         if (fullPath.empty()) return false;
 
-        auto fs = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::READ);
+        auto fs = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::READ).release();
         if (!fs)
         {
             return false;
@@ -187,7 +187,7 @@ bool FontFreeType::createFontObject(const std::string &fontName, float fontSize)
         fts->size = fs->tell();
         fs->seek(0, SEEK_SET);
 
-        fts->descriptor.pointer = fs.release();
+        fts->descriptor.pointer = fs;
 
         FT_Open_Args args = { 0 };
         args.flags = FT_OPEN_STREAM;

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -174,7 +174,7 @@ bool FontFreeType::createFontObject(const std::string &fontName, float fontSize)
         auto fullPath = FileUtils::getInstance()->fullPathForFilename(fontName);
         if (fullPath.empty()) return false;
 
-        FileStream* fs = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::READ);
+        auto fs = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::READ);
         if (!fs)
         {
             return false;
@@ -187,7 +187,7 @@ bool FontFreeType::createFontObject(const std::string &fontName, float fontSize)
         fts->size = fs->tell();
         fs->seek(0, SEEK_SET);
 
-        fts->descriptor.pointer = fs;
+        fts->descriptor.pointer = fs.release();
 
         FT_Open_Args args = { 0 };
         args.flags = FT_OPEN_STREAM;

--- a/cocos/audio/include/AudioDecoderMp3.h
+++ b/cocos/audio/include/AudioDecoderMp3.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "audio/include/AudioDecoder.h"
+#include <memory>
 
 #if !defined(CC_USE_MPG123)
 #define CC_USE_MPG123 0
@@ -80,7 +81,7 @@ protected:
     static bool lazyInit();
     static void destroy();
 
-    FileStream* _fileStream = nullptr;
+    std::unique_ptr<FileStream> _fileStream = nullptr;
     mp3dec_handle_t _handle;
 
     friend class AudioDecoderManager;

--- a/cocos/audio/include/AudioDecoderMp3.h
+++ b/cocos/audio/include/AudioDecoderMp3.h
@@ -81,7 +81,7 @@ protected:
     static bool lazyInit();
     static void destroy();
 
-    std::unique_ptr<FileStream> _fileStream = nullptr;
+    std::unique_ptr<FileStream> _fileStream{};
     mp3dec_handle_t _handle;
 
     friend class AudioDecoderManager;

--- a/cocos/audio/include/AudioDecoderOgg.h
+++ b/cocos/audio/include/AudioDecoderOgg.h
@@ -28,6 +28,7 @@
 #include "audio/include/AudioDecoder.h"
 
 #include "vorbis/vorbisfile.h"
+#include <memory>
 
 namespace cocos2d {
 
@@ -68,7 +69,7 @@ protected:
     AudioDecoderOgg();
     ~AudioDecoderOgg();
 
-    FileStream* _fileStream = nullptr;
+    std::unique_ptr<FileStream> _fileStream = nullptr;
     OggVorbis_File _vf;
 
     friend class AudioDecoderManager;

--- a/cocos/audio/include/AudioDecoderOgg.h
+++ b/cocos/audio/include/AudioDecoderOgg.h
@@ -69,7 +69,6 @@ protected:
     AudioDecoderOgg();
     ~AudioDecoderOgg();
 
-    std::unique_ptr<FileStream> _fileStream{};
     OggVorbis_File _vf;
 
     friend class AudioDecoderManager;

--- a/cocos/audio/include/AudioDecoderOgg.h
+++ b/cocos/audio/include/AudioDecoderOgg.h
@@ -69,7 +69,7 @@ protected:
     AudioDecoderOgg();
     ~AudioDecoderOgg();
 
-    std::unique_ptr<FileStream> _fileStream = nullptr;
+    std::unique_ptr<FileStream> _fileStream{};
     OggVorbis_File _vf;
 
     friend class AudioDecoderManager;

--- a/cocos/audio/include/AudioDecoderWav.h
+++ b/cocos/audio/include/AudioDecoderWav.h
@@ -107,7 +107,7 @@ struct WAV_FILE
     WAV_FILE_HEADER FileHeader;
     AUDIO_SOURCE_FORMAT SourceFormat;
     uint32_t PcmDataOffset;
-    std::unique_ptr<FileStream> Stream = nullptr;
+    std::unique_ptr<FileStream> Stream{};
 };
 
 

--- a/cocos/audio/include/AudioDecoderWav.h
+++ b/cocos/audio/include/AudioDecoderWav.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "audio/include/AudioDecoder.h"
+#include <memory>
 
 #if !defined(MAKE_FOURCC)
 #define MAKE_FOURCC(a,b,c,d) ((uint32_t)((a) | ((b) << 8) | ((c) << 16) | (((uint32_t)(d)) << 24)))
@@ -106,7 +107,7 @@ struct WAV_FILE
     WAV_FILE_HEADER FileHeader;
     AUDIO_SOURCE_FORMAT SourceFormat;
     uint32_t PcmDataOffset;
-    cocos2d::FileStream* Stream = nullptr;
+    std::unique_ptr<FileStream> Stream = nullptr;
 };
 
 

--- a/cocos/audio/src/AudioDecoderMp3.cpp
+++ b/cocos/audio/src/AudioDecoderMp3.cpp
@@ -248,7 +248,7 @@ namespace cocos2d {
 
                 delete _handle;
                 _handle = nullptr;
-                _fileStream = nullptr;
+                _fileStream.reset();
             }
 #else
             if (_handle != nullptr)
@@ -257,8 +257,7 @@ namespace cocos2d {
                 mpg123_delete(_handle);
                 _handle = nullptr;
 
-                delete _fileStream;
-                _fileStream = nullptr;
+                _fileStream.reset();
             }
 #endif
             _isOpened = false;

--- a/cocos/audio/src/AudioDecoderMp3.cpp
+++ b/cocos/audio/src/AudioDecoderMp3.cpp
@@ -128,7 +128,6 @@ namespace cocos2d {
 #if !CC_USE_MPG123
         do
         {
-            delete _fileStream;
             _fileStream = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::READ);
             if (!_fileStream)
             {
@@ -140,7 +139,7 @@ namespace cocos2d {
 
             handle->_decIO.read = minimp3_read_r;
             handle->_decIO.seek = minimp3_seek_r;
-            handle->_decIO.read_data = handle->_decIO.seek_data = _fileStream;
+            handle->_decIO.read_data = handle->_decIO.seek_data = _fileStream.get();
 
             if (mp3dec_ex_open_cb(&handle->_dec, &handle->_decIO, MP3D_SEEK_TO_SAMPLE) != 0)
             {
@@ -249,8 +248,6 @@ namespace cocos2d {
 
                 delete _handle;
                 _handle = nullptr;
-
-                delete _fileStream;
                 _fileStream = nullptr;
             }
 #else

--- a/cocos/audio/src/AudioDecoderOgg.cpp
+++ b/cocos/audio/src/AudioDecoderOgg.cpp
@@ -56,6 +56,8 @@ namespace cocos2d {
     }
 
     static int ov_fclose_r(void* handle) {
+        auto* fs = static_cast<FileStream*>(handle);
+        delete fs;
         return 0;
     }
     
@@ -70,8 +72,8 @@ namespace cocos2d {
 
     bool AudioDecoderOgg::open(const std::string& fullPath)
     {
-        _fileStream = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::READ);
-        if (!_fileStream)
+        auto fs = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::READ).release();
+        if (!fs)
         {
             ALOGE("Trouble with ogg(1): %s\n", strerror(errno));
             return false;
@@ -83,8 +85,8 @@ namespace cocos2d {
                ov_fclose_r,
                ov_ftell_r
         };
-              
-        if (0 == ov_open_callbacks(_fileStream.get(), &_vf, nullptr, 0, OV_CALLBACKS_POSIX))
+
+        if (0 == ov_open_callbacks(fs, &_vf, nullptr, 0, OV_CALLBACKS_POSIX))
         {
             // header
             vorbis_info* vi = ov_info(&_vf, -1);
@@ -104,7 +106,6 @@ namespace cocos2d {
         {
             ov_clear(&_vf);
             _isOpened = false;
-            _fileStream.reset();
         }
     }
 

--- a/cocos/audio/src/AudioDecoderOgg.cpp
+++ b/cocos/audio/src/AudioDecoderOgg.cpp
@@ -39,21 +39,25 @@ namespace cocos2d {
 
     static size_t ov_fread_r(void* buffer, size_t element_size, size_t element_count, void* handle)
     {
-        return ((FileStream*)handle)->read(buffer, static_cast<uint32_t>(element_size * element_count));
+        auto& fs = *static_cast<std::unique_ptr<FileStream>*>(handle);
+        return fs->read(buffer, static_cast<uint32_t>(element_size * element_count));
     }
 
     static int ov_fseek_r(void * handle, ogg_int64_t offset, int whence)
     {
-        return ((FileStream*)handle)->seek(offset, whence) < 0 ? -1 : 0;
+        auto& fs = *static_cast<std::unique_ptr<FileStream>*>(handle);
+        return fs->seek(offset, whence) < 0 ? -1 : 0;
     }
     
     static long ov_ftell_r(void * handle)
     {
-        return ((FileStream*)handle)->seek(0, SEEK_CUR);
+        auto& fs = *static_cast<std::unique_ptr<FileStream>*>(handle);
+        return fs->tell();
     }
 
     static int ov_fclose_r(void* handle) {
-        ((FileStream*)handle)->close();
+        auto& fs = *static_cast<std::unique_ptr<FileStream>*>(handle);
+        fs = nullptr;
         return 0;
     }
     
@@ -102,6 +106,7 @@ namespace cocos2d {
         {
             ov_clear(&_vf);
             _isOpened = false;
+            _fileStream = nullptr;
         }
     }
 

--- a/cocos/audio/src/AudioDecoderOgg.cpp
+++ b/cocos/audio/src/AudioDecoderOgg.cpp
@@ -39,25 +39,23 @@ namespace cocos2d {
 
     static size_t ov_fread_r(void* buffer, size_t element_size, size_t element_count, void* handle)
     {
-        auto& fs = *static_cast<std::unique_ptr<FileStream>*>(handle);
+        auto* fs = static_cast<FileStream*>(handle);
         return fs->read(buffer, static_cast<uint32_t>(element_size * element_count));
     }
 
     static int ov_fseek_r(void * handle, ogg_int64_t offset, int whence)
     {
-        auto& fs = *static_cast<std::unique_ptr<FileStream>*>(handle);
+        auto* fs = static_cast<FileStream*>(handle);
         return fs->seek(offset, whence) < 0 ? -1 : 0;
     }
     
     static long ov_ftell_r(void * handle)
     {
-        auto& fs = *static_cast<std::unique_ptr<FileStream>*>(handle);
+        auto* fs = static_cast<FileStream*>(handle);
         return fs->tell();
     }
 
     static int ov_fclose_r(void* handle) {
-        auto& fs = *static_cast<std::unique_ptr<FileStream>*>(handle);
-        fs = nullptr;
         return 0;
     }
     
@@ -86,7 +84,7 @@ namespace cocos2d {
                ov_ftell_r
         };
               
-        if (0 == ov_open_callbacks(&_fileStream, &_vf, nullptr, 0, OV_CALLBACKS_POSIX))
+        if (0 == ov_open_callbacks(_fileStream.get(), &_vf, nullptr, 0, OV_CALLBACKS_POSIX))
         {
             // header
             vorbis_info* vi = ov_info(&_vf, -1);
@@ -106,7 +104,7 @@ namespace cocos2d {
         {
             ov_clear(&_vf);
             _isOpened = false;
-            _fileStream = nullptr;
+            _fileStream.reset();
         }
     }
 

--- a/cocos/audio/src/AudioDecoderWav.cpp
+++ b/cocos/audio/src/AudioDecoderWav.cpp
@@ -161,7 +161,7 @@ namespace cocos2d {
     static int wav_close(WAV_FILE* wavf)
     {
         const auto result = wavf->Stream->close();
-        wavf->Stream = nullptr;
+        wavf->Stream.reset();
         return result;
     }
 

--- a/cocos/audio/src/AudioDecoderWav.cpp
+++ b/cocos/audio/src/AudioDecoderWav.cpp
@@ -132,13 +132,13 @@ namespace cocos2d {
             if (!IsEqualGUID(fmtInfo.ExtParams.SubFormat, WAV_SUBTYPE_PCM)
                 && !IsEqualGUID(fmtInfo.ExtParams.SubFormat, WAV_SUBTYPE_IEEE_FLOAT))
             {
-                fileStream = nullptr;
+                fileStream.reset();
                 return false;
             }
             break;
         default:
             ALOGW("The wav format %d doesn't supported currently!", (int)fmtInfo.AudioFormat);
-            fileStream = nullptr;
+            fileStream.reset();
             assert(false);
             return false;
         }

--- a/cocos/audio/src/AudioDecoderWav.cpp
+++ b/cocos/audio/src/AudioDecoderWav.cpp
@@ -76,7 +76,6 @@ namespace cocos2d {
     }
     static bool wav_open(const std::string& fullPath, WAV_FILE* wavf)
     {
-        delete wavf->Stream;
         wavf->Stream = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::READ);
         if (!wavf->Stream)
             return false;
@@ -133,13 +132,13 @@ namespace cocos2d {
             if (!IsEqualGUID(fmtInfo.ExtParams.SubFormat, WAV_SUBTYPE_PCM)
                 && !IsEqualGUID(fmtInfo.ExtParams.SubFormat, WAV_SUBTYPE_IEEE_FLOAT))
             {
-                fileStream->close();
+                fileStream = nullptr;
                 return false;
             }
             break;
         default:
             ALOGW("The wav format %d doesn't supported currently!", (int)fmtInfo.AudioFormat);
-            fileStream->close();
+            fileStream = nullptr;
             assert(false);
             return false;
         }
@@ -162,7 +161,6 @@ namespace cocos2d {
     static int wav_close(WAV_FILE* wavf)
     {
         const auto result = wavf->Stream->close();
-        delete wavf->Stream;
         wavf->Stream = nullptr;
         return result;
     }

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -1491,7 +1491,7 @@ void Console::commandUpload(int fd)
     static std::string writablePath = FileUtils::getInstance()->getWritablePath();
     std::string filepath = writablePath + std::string(buf);
 
-    auto* fs = FileUtils::getInstance()->openFileStream(filepath, FileStream::Mode::WRITE);
+    auto fs = FileUtils::getInstance()->openFileStream(filepath, FileStream::Mode::WRITE);
     if(!fs)
     {
         const char err[] = "can't create file!\n";
@@ -1521,8 +1521,6 @@ void Console::commandUpload(int fd)
         }
         free(decode);
     }
-    fs->close();
-    delete fs;
 }
 
 void Console::commandVersion(int fd, const std::string& /*args*/)

--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -554,7 +554,7 @@ voidpf ZipFile_open_file_func(voidpf opaque, const char* filename, int mode)
     else
         return nullptr;
 
-    return FileUtils::getInstance()->openFileStream(filename, fsMode);
+    return FileUtils::getInstance()->openFileStream(filename, fsMode).release();
 }
 
 voidpf ZipFile_opendisk_file_func(voidpf opaque, voidpf stream, uint32_t number_disk, int mode)
@@ -603,7 +603,9 @@ int ZipFile_close_file_func(voidpf opaque, voidpf stream)
         return -1;
 
     auto* fs = (FileStream*)stream;
-    return fs->close(); // 0 for success, -1 for error
+    const auto result = fs->close(); // 0 for success, -1 for error
+    delete fs;
+    return result;
 }
 
 // THis isn't supported by FileStream, so just check if the stream is null and open

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -86,8 +86,8 @@ public:
             }
         }
 
-        delete _fs;
-        delete _fsMd5;
+        _fs = nullptr;
+        _fsMd5 = nullptr;
 
         if (_requestHeaders)
             curl_slist_free_all(_requestHeaders);
@@ -284,10 +284,10 @@ private:
     string _tempFileName;
     std::string _checksumFileName;
     vector<unsigned char> _buf;
-    FileStream* _fs = nullptr;
+    std::unique_ptr<FileStream> _fs = nullptr;
 
     // calculate md5 in downloading time support
-    FileStream* _fsMd5 = nullptr; // store md5 state realtime
+    std::unique_ptr<FileStream> _fsMd5 = nullptr; // store md5 state realtime
     md5_state_s _md5State;
 
 
@@ -813,14 +813,12 @@ void DownloaderCURL::_onDownloadFinished(TaskWrapper&& wrapper, int checkState) 
     if (coTask._fs) {
         do {
             auto pFileUtils = FileUtils::getInstance();
-            delete coTask._fs;
             coTask._fs = nullptr;
-            delete coTask._fsMd5;
             coTask._fsMd5 = nullptr;
 
             if (checkState & kCheckSumStateSucceed) // No need download
             {
-                auto* fsOrigin = pFileUtils->openFileStream(coTask._fileName, FileStream::Mode::READ);
+                auto fsOrigin = pFileUtils->openFileStream(coTask._fileName, FileStream::Mode::READ);
                 if (fsOrigin) {
                     fsOrigin->seek(0, SEEK_END);
                     task.progressInfo.totalBytesExpected = fsOrigin->tell();
@@ -835,7 +833,6 @@ void DownloaderCURL::_onDownloadFinished(TaskWrapper&& wrapper, int checkState) 
 
                     onTaskProgress(task, _transferDataToBuffer);
 
-                    delete fsOrigin;
                     fsOrigin = nullptr;
                 } else {
                     coTask._errCode         = DownloadTask::ERROR_ORIGIN_FILE_MISSING;

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -86,8 +86,8 @@ public:
             }
         }
 
-        _fs = nullptr;
-        _fsMd5 = nullptr;
+        _fs.reset();
+        _fsMd5.reset();
 
         if (_requestHeaders)
             curl_slist_free_all(_requestHeaders);
@@ -284,10 +284,10 @@ private:
     string _tempFileName;
     std::string _checksumFileName;
     vector<unsigned char> _buf;
-    std::unique_ptr<FileStream> _fs = nullptr;
+    std::unique_ptr<FileStream> _fs{};
 
     // calculate md5 in downloading time support
-    std::unique_ptr<FileStream> _fsMd5 = nullptr; // store md5 state realtime
+    std::unique_ptr<FileStream> _fsMd5{}; // store md5 state realtime
     md5_state_s _md5State;
 
 
@@ -813,8 +813,8 @@ void DownloaderCURL::_onDownloadFinished(TaskWrapper&& wrapper, int checkState) 
     if (coTask._fs) {
         do {
             auto pFileUtils = FileUtils::getInstance();
-            coTask._fs = nullptr;
-            coTask._fsMd5 = nullptr;
+            coTask._fs.reset();
+            coTask._fsMd5.reset();
 
             if (checkState & kCheckSumStateSucceed) // No need download
             {

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include <unordered_map>
 #include <type_traits>
 #include <mutex>
+#include <memory>
 
 #include "platform/CCFileStream.h"
 #include "platform/CCPlatformMacros.h"
@@ -854,7 +855,7 @@ public:
      *  @param mode The mode to open the file in, being READ | WRITE | APPEND
      *  @return Returns a pointer to the file stream
      */
-    virtual FileStream* openFileStream(const std::string& filePath, FileStream::Mode mode);
+    virtual std::unique_ptr<FileStream> openFileStream(const std::string& filePath, FileStream::Mode mode);
 
 protected:
     /**

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -2178,7 +2178,7 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
         png_infop info_ptr;
         png_bytep *row_pointers;
         
-        auto* outStream = FileUtils::getInstance()->openFileStream(filePath, FileStream::Mode::WRITE);
+        auto outStream = FileUtils::getInstance()->openFileStream(filePath, FileStream::Mode::WRITE);
 
         CC_BREAK_IF(nullptr == outStream);
 
@@ -2186,26 +2186,26 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
 
         if (nullptr == png_ptr)
         {
-            delete outStream;
+            outStream = nullptr;
             break;
         }
 
         info_ptr = png_create_info_struct(png_ptr);
         if (nullptr == info_ptr)
         {
-            delete outStream;
+            outStream = nullptr;
             png_destroy_write_struct(&png_ptr, nullptr);
             break;
         }
         if (setjmp(png_jmpbuf(png_ptr)))
         {
-            delete outStream;
+            outStream = nullptr;
             png_destroy_write_struct(&png_ptr, &info_ptr);
             break;
         }
 
         //png_init_io(png_ptr, outStream);
-        png_set_write_fn(png_ptr, outStream, pngWriteCallback, nullptr);
+        png_set_write_fn(png_ptr, outStream.get(), pngWriteCallback, nullptr);
 
         if (!isToRGB && hasAlpha())
         {
@@ -2225,7 +2225,7 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
         row_pointers = (png_bytep *)malloc(_height * sizeof(png_bytep));
         if(row_pointers == nullptr)
         {
-            delete outStream;
+            outStream = nullptr;
             png_destroy_write_struct(&png_ptr, &info_ptr);
             break;
         }
@@ -2249,7 +2249,7 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
                 uint8_t *tempData = static_cast<uint8_t*>(malloc(_width * _height * 3));
                 if (nullptr == tempData)
                 {
-                    delete outStream;
+                    outStream = nullptr;
                     png_destroy_write_struct(&png_ptr, &info_ptr);
                     
                     free(row_pointers);
@@ -2300,7 +2300,7 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
 
         png_destroy_write_struct(&png_ptr, &info_ptr);
 
-        delete outStream;
+        outStream = nullptr;
 
         ret = true;
     } while (0);
@@ -2319,7 +2319,7 @@ bool Image::saveImageToJPG(const std::string& filePath)
     {
         struct jpeg_compress_struct cinfo;
         struct jpeg_error_mgr jerr;
-        FileStream * outfile;                 /* target file */
+        std::unique_ptr<FileStream> outfile;                 /* target file */
         JSAMPROW row_pointer[1];        /* pointer to JSAMPLE row[s] */
         int     row_stride;          /* physical row width in image buffer */
 
@@ -2354,7 +2354,6 @@ bool Image::saveImageToJPG(const std::string& filePath)
                 jpeg_finish_compress(&cinfo);
                 jpeg_destroy_compress(&cinfo);
 
-                delete outfile;
                 outfile = nullptr;
                 if (outputBuffer)
                 {
@@ -2397,8 +2396,8 @@ bool Image::saveImageToJPG(const std::string& filePath)
         jpeg_finish_compress(&cinfo);
 
         outfile->write(outputBuffer, outputSize);
-        delete outfile; // closes FileStream automatically
         outfile = nullptr;
+
         if (outputBuffer)
         {
             free(outputBuffer);

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -2186,20 +2186,20 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
 
         if (nullptr == png_ptr)
         {
-            outStream = nullptr;
+            outStream.reset();
             break;
         }
 
         info_ptr = png_create_info_struct(png_ptr);
         if (nullptr == info_ptr)
         {
-            outStream = nullptr;
+            outStream.reset();
             png_destroy_write_struct(&png_ptr, nullptr);
             break;
         }
         if (setjmp(png_jmpbuf(png_ptr)))
         {
-            outStream = nullptr;
+            outStream.reset();
             png_destroy_write_struct(&png_ptr, &info_ptr);
             break;
         }
@@ -2225,7 +2225,7 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
         row_pointers = (png_bytep *)malloc(_height * sizeof(png_bytep));
         if(row_pointers == nullptr)
         {
-            outStream = nullptr;
+            outStream.reset();
             png_destroy_write_struct(&png_ptr, &info_ptr);
             break;
         }
@@ -2249,7 +2249,7 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
                 uint8_t *tempData = static_cast<uint8_t*>(malloc(_width * _height * 3));
                 if (nullptr == tempData)
                 {
-                    outStream = nullptr;
+                    outStream.reset();
                     png_destroy_write_struct(&png_ptr, &info_ptr);
                     
                     free(row_pointers);
@@ -2300,7 +2300,7 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
 
         png_destroy_write_struct(&png_ptr, &info_ptr);
 
-        outStream = nullptr;
+        outStream.reset();
 
         ret = true;
     } while (0);
@@ -2354,7 +2354,7 @@ bool Image::saveImageToJPG(const std::string& filePath)
                 jpeg_finish_compress(&cinfo);
                 jpeg_destroy_compress(&cinfo);
 
-                outfile = nullptr;
+                outfile.reset();
                 if (outputBuffer)
                 {
                     free(outputBuffer);
@@ -2396,7 +2396,7 @@ bool Image::saveImageToJPG(const std::string& filePath)
         jpeg_finish_compress(&cinfo);
 
         outfile->write(outputBuffer, outputSize);
-        outfile = nullptr;
+        outfile.reset();
 
         if (outputBuffer)
         {

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -348,7 +348,6 @@ public:
             fontPath = cocos2d::FileUtils::getInstance()->fullPathForFilename(fontPath);
             auto fileStream = cocos2d::FileUtils::getInstance()->openFileStream(fontPath, FileStream::Mode::READ);
             if ( fileStream ) {
-                fileStream = nullptr;
                 fontCache.insert(std::pair<std::string, std::string>(family_name, fontPath));
                 return fontPath;
             }

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -346,9 +346,9 @@ public:
         std::transform(lowerCasePath.begin(), lowerCasePath.end(), lowerCasePath.begin(), ::tolower);
         if ( lowerCasePath.find(".ttf") != std::string::npos ) {
             fontPath = cocos2d::FileUtils::getInstance()->fullPathForFilename(fontPath);
-            auto* fileStream = cocos2d::FileUtils::getInstance()->openFileStream(fontPath, FileStream::Mode::READ);
+            auto fileStream = cocos2d::FileUtils::getInstance()->openFileStream(fontPath, FileStream::Mode::READ);
             if ( fileStream ) {
-                delete fileStream;
+                fileStream = nullptr;
                 fontCache.insert(std::pair<std::string, std::string>(family_name, fontPath));
                 return fontPath;
             }

--- a/extensions/assets-manager/AssetsManager.cpp
+++ b/extensions/assets-manager/AssetsManager.cpp
@@ -469,7 +469,7 @@ bool AssetsManager::uncompress()
                 }
                 else
                 {
-                    fsOut = nullptr;
+                    fsOut.reset();
                 }
                 
                 startIndex=index+1;
@@ -507,7 +507,7 @@ bool AssetsManager::uncompress()
                     CCLOG("can not read zip file %s, error code is %d", fileName, error);
                     unzCloseCurrentFile(zipfile);
                     unzClose(zipfile);
-                    fsOut = nullptr;
+                    fsOut.reset();
                     return false;
                 }
                 
@@ -517,7 +517,7 @@ bool AssetsManager::uncompress()
                 }
             } while(error > 0);
 
-            fsOut = nullptr;
+            fsOut.reset();
         }
         
         unzCloseCurrentFile(zipfile);

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -529,7 +529,7 @@ bool AssetsManagerEx::decompress(const std::string &zip)
                 if (error < 0)
                 {
                     CCLOG("AssetsManagerEx : can not read zip file %s, error code is %d\n", fileName, error);
-                    fsOut = nullptr;
+                    fsOut.reset();
                     unzCloseCurrentFile(zipfile);
                     unzClose(zipfile);
                     return false;
@@ -541,7 +541,7 @@ bool AssetsManagerEx::decompress(const std::string &zip)
                 }
             } while(error > 0);
             
-            fsOut = nullptr;
+            fsOut.reset();
         }
         
         unzCloseCurrentFile(zipfile);

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -92,7 +92,7 @@ voidpf AssetManagerEx_open_file_func(voidpf opaque, const char* filename, int mo
     else
         return nullptr;
 
-    return FileUtils::getInstance()->openFileStream(filename, fsMode);
+    return FileUtils::getInstance()->openFileStream(filename, fsMode).release();
 }
 
 voidpf AssetManagerEx_opendisk_file_func(voidpf opaque, voidpf stream, uint32_t number_disk, int mode)
@@ -141,7 +141,9 @@ int AssetManagerEx_close_file_func(voidpf opaque, voidpf stream)
         return -1;
 
     auto* fs = (FileStream*)stream;
-    return fs->close(); // 0 for success, -1 for error
+    const auto result = fs->close(); // 0 for success, -1 for error
+    delete fs;
+    return result;
 }
 
 // THis isn't supported by FileStream, so just check if the stream is null and open
@@ -510,7 +512,7 @@ bool AssetsManagerEx::decompress(const std::string &zip)
             }
             
             // Create a file to store current file.
-            auto* fsOut = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::WRITE);
+            auto fsOut = FileUtils::getInstance()->openFileStream(fullPath, FileStream::Mode::WRITE);
             if (!fsOut)
             {
                 CCLOG("AssetsManagerEx : can not create decompress destination file %s (errno: %d)\n", fullPath.c_str(), errno);
@@ -527,7 +529,7 @@ bool AssetsManagerEx::decompress(const std::string &zip)
                 if (error < 0)
                 {
                     CCLOG("AssetsManagerEx : can not read zip file %s, error code is %d\n", fileName, error);
-                    delete fsOut;
+                    fsOut = nullptr;
                     unzCloseCurrentFile(zipfile);
                     unzClose(zipfile);
                     return false;
@@ -539,7 +541,7 @@ bool AssetsManagerEx::decompress(const std::string &zip)
                 }
             } while(error > 0);
             
-            delete fsOut;
+            fsOut = nullptr;
         }
         
         unzCloseCurrentFile(zipfile);


### PR DESCRIPTION
While I was updating the code to use unique_ptr, I found a few issues with zip close method overrides not correctly freeing the FileStream data, so they've been fixed as well (in ZipUtils, AssetManager and AssetManagerEx)